### PR TITLE
Add missing component dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,4 +2,5 @@ idf_component_register(
   SRCS "src/esp32_udp_logger.c"
   INCLUDE_DIRS "include"
   REQUIRES lwip
+  PRIV_REQUIRES esp_event wolfssl__wolfssl
 )


### PR DESCRIPTION
## Summary
- add esp_event and wolfssl__wolfssl as private dependencies for the UDP logger component

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69418ede7fc883219f04fd84057da1aa)