### PR TITLE
Add mdns dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,5 +2,5 @@ idf_component_register(
   SRCS "src/esp32_udp_logger.c"
   INCLUDE_DIRS "include"
   REQUIRES lwip
-  PRIV_REQUIRES esp_event esp_netif
+  PRIV_REQUIRES esp_event esp_netif mdns
 )


### PR DESCRIPTION
## Summary
- add the mdns component as a private requirement for the esp32 UDP logger component

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69419c9533b083219a71c7c6662b7bb9)