### PR TITLE
Add menuconfig option to skip esp_netif_init() in autostart

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -55,6 +55,15 @@ config ESP32_UDP_LOGGER_ENABLE_MDNS
     default y
     depends on ESP32_UDP_LOGGER_ENABLED
 
+config ESP32_UDP_LOGGER_AUTOSTART_INIT_NETIF
+    bool "Call esp_netif_init() in esp32_udp_logger_autostart()"
+    default y
+    depends on ESP32_UDP_LOGGER_ENABLED
+    help
+        Disable this when your application already initializes networking
+        (for example, components that bring up ESP-NETIF/LwIP before
+        esp32-udp-logger is started).
+
 config ESP32_UDP_LOGGER_SERVICE
     bool "Advertise mDNS service _esp32udplog._udp"
     default y

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Once the ESP32 gets an IP (Wi‑Fi STA or Ethernet):
 You can change these via `menuconfig`:
 `Component config → esp32-udp-logger`.
 
+For apps that already initialize networking, you can disable internal netif init:
+`Component config → esp32-udp-logger → Call esp_netif_init() in esp32_udp_logger_autostart()`.
+
+
 ---
 
 # Quick start (single device)
@@ -210,6 +214,14 @@ echo "bind 192.168.1.10 9999" | nc -u -w1 esp32-udp-logger-7A3F.local 9998
   ```bash
   python tools/esp32_udp_logger_cli.py listen
   ```
+
+## Crash/assert around socket creation (Invalid mbox)
+If your app already sets up networking/LwIP, disable:
+`Component config → esp32-udp-logger → Call esp_netif_init() in esp32_udp_logger_autostart()`.
+
+Also ensure LwIP allows enough UDP sockets for your app + logger. This component uses two UDP sockets (TX + RX), so increase:
+`Component config → LWIP → UDP → The maximum number of active UDP "connections"` (for example 2 or more).
+
 
 ## `list` shows no devices
 mDNS can be blocked:

--- a/src/esp32_udp_logger.c
+++ b/src/esp32_udp_logger.c
@@ -445,8 +445,10 @@ void esp32_udp_logger_autostart(void)
 
   esp_err_t e;
 
+#if CONFIG_ESP32_UDP_LOGGER_AUTOSTART_INIT_NETIF
   e = esp_netif_init();
   if (e != ESP_OK && e != ESP_ERR_INVALID_STATE) return;
+#endif
 
   e = esp_event_loop_create_default();
   if (e != ESP_OK && e != ESP_ERR_INVALID_STATE) return;


### PR DESCRIPTION
### Motivation
- Some applications already initialize networking and crash or assert when `esp32_udp_logger_autostart()` calls `esp_netif_init()`, so a configurable opt-out is needed. 

### Description
- Added a new Kconfig option `ESP32_UDP_LOGGER_AUTOSTART_INIT_NETIF` (default `y`) to control whether `esp32_udp_logger_autostart()` calls `esp_netif_init()` (file `Kconfig`).
- Gated the `esp_netif_init()` call in `src/esp32_udp_logger.c` behind `ESP32_UDP_LOGGER_AUTOSTART_INIT_NETIF`, preserving current defaults but allowing host apps to disable it.
- Updated `README.md` to document the new menuconfig option and added troubleshooting guidance for the `Invalid mbox` assert, including increasing the LWIP UDP PCB count since the component uses two UDP sockets (TX + RX).

### Testing
- Ran the component CLI unit tests with `python -m pytest -q tools/test_esp32_udp_logger_cli.py` and all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f2d8aa10483219f9561685ce5f1b3)