### PR TITLE
add function to set custom hostname

### DIFF
--- a/include/esp32_udp_logger.h
+++ b/include/esp32_udp_logger.h
@@ -31,6 +31,7 @@ void esp32_udp_logger_unbind(void);
 void esp32_udp_logger_set_broadcast(bool enable);
 
 uint32_t esp32_udp_logger_get_drop_count(void);
+int esp32_udp_logger_set_hostname(const char *str);
 const char *esp32_udp_logger_get_hostname(void);
 
 #ifdef __cplusplus

--- a/src/esp32_udp_logger.c
+++ b/src/esp32_udp_logger.c
@@ -25,10 +25,6 @@
 
 #include "sdkconfig.h"
 
-#ifndef CONFIG_ESP32_UDP_LOGGER_ENABLED
-#define CONFIG_ESP32_UDP_LOGGER_ENABLED 1
-#endif
-
 #if CONFIG_ESP32_UDP_LOGGER_ENABLED
 
 typedef struct {

--- a/src/esp32_udp_logger.c
+++ b/src/esp32_udp_logger.c
@@ -84,6 +84,15 @@ static void make_hostname_once(void)
   snprintf(s_hostname, sizeof(s_hostname), "esp32-udp-logger-%02X%02X", mac[4], mac[5]);
 }
 
+int esp32_udp_logger_set_hostname(const char *str)
+{
+  if (!str || s_hostname[0] != 0) return -1;
+
+  snprintf(s_hostname, sizeof(s_hostname), str);
+  
+  return 0;
+}
+
 const char *esp32_udp_logger_get_hostname(void)
 {
   return s_hostname;


### PR DESCRIPTION
some applications will have a hostname configured already. With this it is possible to set a custom hostname when calling `esp32_udp_logger_autostart()` mannually like so

```
esp32_udp_logger_set_hostname(mdns_hostname);
esp32_udp_logger_autostart();
```

also fix #9 